### PR TITLE
PORTALS-2936 - Update types, mocks, handlers

### DIFF
--- a/packages/synapse-react-client/src/components/AccessRequirementList/AccessRequirementList.stories.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/AccessRequirementList.stories.tsx
@@ -114,8 +114,8 @@ export const HasMetRequirements: Story = {
         ...getAccessRequirementHandlers(MOCK_REPO_ORIGIN),
         ...getAccessRequirementEntityBindingHandlers(MOCK_REPO_ORIGIN),
 
-        ...getAccessRequirementStatusHandlers(MOCK_REPO_ORIGIN, {
-          [mockManagedACTAccessRequirement.id.toString()]: {
+        ...getAccessRequirementStatusHandlers(MOCK_REPO_ORIGIN, [
+          {
             accessRequirementId: mockManagedACTAccessRequirement.id.toString(),
             concreteType:
               'org.sagebionetworks.repo.model.dataaccess.ManagedACTAccessRequirementStatus',
@@ -128,27 +128,26 @@ export const HasMetRequirements: Story = {
               state: SubmissionState.APPROVED,
             },
           },
-          [mockSelfSignAccessRequirement.id.toString()]: {
+          {
             accessRequirementId: mockSelfSignAccessRequirement.id.toString(),
             concreteType:
               'org.sagebionetworks.repo.model.dataaccess.BasicAccessRequirementStatus',
             isApproved: true,
           },
 
-          [mockToUAccessRequirement.id.toString()]: {
+          {
             accessRequirementId: mockToUAccessRequirement.id.toString(),
             concreteType:
               'org.sagebionetworks.repo.model.dataaccess.BasicAccessRequirementStatus',
             isApproved: true,
           },
-
-          [mockACTAccessRequirement.id.toString()]: {
+          {
             accessRequirementId: mockACTAccessRequirement.id.toString(),
             concreteType:
               'org.sagebionetworks.repo.model.dataaccess.BasicAccessRequirementStatus',
             isApproved: true,
           },
-        }),
+        ]),
         ...getWikiHandlers(MOCK_REPO_ORIGIN),
       ],
     },
@@ -169,34 +168,32 @@ export const HasUnmetRequirements: Story = {
         ...getTwoFactorAuthStatusHandler(false),
         ...getAccessRequirementHandlers(MOCK_REPO_ORIGIN),
         ...getAccessRequirementEntityBindingHandlers(MOCK_REPO_ORIGIN),
-        ...getAccessRequirementStatusHandlers(MOCK_REPO_ORIGIN, {
-          [mockManagedACTAccessRequirement.id.toString()]: {
+        ...getAccessRequirementStatusHandlers(MOCK_REPO_ORIGIN, [
+          {
             accessRequirementId: mockManagedACTAccessRequirement.id.toString(),
             concreteType:
               'org.sagebionetworks.repo.model.dataaccess.ManagedACTAccessRequirementStatus',
             isApproved: false,
           },
-          [mockSelfSignAccessRequirement.id.toString()]: {
+          {
             accessRequirementId: mockSelfSignAccessRequirement.id.toString(),
             concreteType:
               'org.sagebionetworks.repo.model.dataaccess.BasicAccessRequirementStatus',
             isApproved: false,
           },
-
-          [mockToUAccessRequirement.id.toString()]: {
+          {
             accessRequirementId: mockToUAccessRequirement.id.toString(),
             concreteType:
               'org.sagebionetworks.repo.model.dataaccess.BasicAccessRequirementStatus',
             isApproved: false,
           },
-
-          [mockACTAccessRequirement.id.toString()]: {
+          {
             accessRequirementId: mockACTAccessRequirement.id.toString(),
             concreteType:
               'org.sagebionetworks.repo.model.dataaccess.BasicAccessRequirementStatus',
             isApproved: false,
           },
-        }),
+        ]),
         ...getWikiHandlers(MOCK_REPO_ORIGIN),
         ...getResearchProjectHandlers(MOCK_REPO_ORIGIN),
         rest.post(
@@ -207,6 +204,12 @@ export const HasUnmetRequirements: Story = {
               submitterId: MOCK_USER_ID.toString(),
               accessorId: MOCK_USER_ID.toString(),
               state: ApprovalState.APPROVED,
+              id: 123,
+              etag: 'etag',
+              createdOn: new Date().toISOString(),
+              modifiedOn: new Date().toISOString(),
+              createdBy: String(MOCK_USER_ID),
+              modifiedBy: String(MOCK_USER_ID),
             }
             return res(ctx.status(201), ctx.json(response))
           },
@@ -230,14 +233,14 @@ export const NotValidated: Story = {
         ...getTwoFactorAuthStatusHandler(true),
         ...getAccessRequirementHandlers(MOCK_REPO_ORIGIN),
         ...getAccessRequirementEntityBindingHandlers(MOCK_REPO_ORIGIN),
-        ...getAccessRequirementStatusHandlers(MOCK_REPO_ORIGIN, {
-          [mockSelfSignAccessRequirement.id.toString()]: {
+        ...getAccessRequirementStatusHandlers(MOCK_REPO_ORIGIN, [
+          {
             accessRequirementId: mockSelfSignAccessRequirement.id.toString(),
             concreteType:
               'org.sagebionetworks.repo.model.dataaccess.BasicAccessRequirementStatus',
             isApproved: false,
           },
-        }),
+        ]),
         ...getWikiHandlers(MOCK_REPO_ORIGIN),
         rest.post(
           `${MOCK_REPO_ORIGIN}${ACCESS_APPROVAL}`,
@@ -247,6 +250,12 @@ export const NotValidated: Story = {
               submitterId: MOCK_USER_ID.toString(),
               accessorId: MOCK_USER_ID.toString(),
               state: ApprovalState.APPROVED,
+              id: 123,
+              etag: 'etag',
+              createdOn: new Date().toISOString(),
+              modifiedOn: new Date().toISOString(),
+              createdBy: String(MOCK_USER_ID),
+              modifiedBy: String(MOCK_USER_ID),
             }
             return res(ctx.status(201), ctx.json(response))
           },
@@ -270,14 +279,14 @@ export const NotCertified: Story = {
         ...getTwoFactorAuthStatusHandler(true),
         ...getAccessRequirementHandlers(MOCK_REPO_ORIGIN),
         ...getAccessRequirementEntityBindingHandlers(MOCK_REPO_ORIGIN),
-        ...getAccessRequirementStatusHandlers(MOCK_REPO_ORIGIN, {
-          [mockSelfSignAccessRequirement.id.toString()]: {
+        ...getAccessRequirementStatusHandlers(MOCK_REPO_ORIGIN, [
+          {
             accessRequirementId: mockSelfSignAccessRequirement.id.toString(),
             concreteType:
               'org.sagebionetworks.repo.model.dataaccess.BasicAccessRequirementStatus',
             isApproved: false,
           },
-        }),
+        ]),
         ...getWikiHandlers(MOCK_REPO_ORIGIN),
         rest.post(
           `${MOCK_REPO_ORIGIN}${ACCESS_APPROVAL}`,
@@ -287,6 +296,12 @@ export const NotCertified: Story = {
               submitterId: MOCK_USER_ID.toString(),
               accessorId: MOCK_USER_ID.toString(),
               state: ApprovalState.APPROVED,
+              id: 123,
+              etag: 'etag',
+              createdOn: new Date().toISOString(),
+              modifiedOn: new Date().toISOString(),
+              createdBy: String(MOCK_USER_ID),
+              modifiedBy: String(MOCK_USER_ID),
             }
             return res(ctx.status(201), ctx.json(response))
           },

--- a/packages/synapse-react-client/src/components/AccessRequirementList/RequirementItem/SelfSignAccessRequirementItem.stories.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/RequirementItem/SelfSignAccessRequirementItem.stories.tsx
@@ -96,6 +96,12 @@ export const RequiresUnmetCertificationAndValidation: Story = {
               submitterId: MOCK_USER_ID.toString(),
               accessorId: MOCK_USER_ID.toString(),
               state: ApprovalState.APPROVED,
+              id: 123,
+              etag: 'etag',
+              createdOn: new Date().toISOString(),
+              modifiedOn: new Date().toISOString(),
+              createdBy: String(MOCK_USER_ID),
+              modifiedBy: String(MOCK_USER_ID),
             }
             return res(ctx.status(201), ctx.json(response))
           },
@@ -137,6 +143,12 @@ export const LegacyTermsOfUse: Story = {
               submitterId: MOCK_USER_ID.toString(),
               accessorId: MOCK_USER_ID.toString(),
               state: ApprovalState.APPROVED,
+              id: 123,
+              etag: 'etag',
+              createdOn: new Date().toISOString(),
+              modifiedOn: new Date().toISOString(),
+              createdBy: String(MOCK_USER_ID),
+              modifiedBy: String(MOCK_USER_ID),
             }
             return res(ctx.status(201), ctx.json(response))
           },
@@ -178,6 +190,12 @@ export const LegacyTermsOfUseWithWiki: Story = {
               submitterId: MOCK_USER_ID.toString(),
               accessorId: MOCK_USER_ID.toString(),
               state: ApprovalState.APPROVED,
+              id: 123,
+              etag: 'etag',
+              createdOn: new Date().toISOString(),
+              modifiedOn: new Date().toISOString(),
+              createdBy: String(MOCK_USER_ID),
+              modifiedBy: String(MOCK_USER_ID),
             }
             return res(ctx.status(201), ctx.json(response))
           },

--- a/packages/synapse-react-client/src/components/AccessRequirementList/RequirementItem/SelfSignAccessRequirementItem.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/RequirementItem/SelfSignAccessRequirementItem.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react'
 import MarkdownSynapse from '../../Markdown/MarkdownSynapse'
 import {
-  AccessApproval,
   ApprovalState,
+  CreateAccessApprovalRequest,
   SelfSignAccessRequirement,
   TermsOfUseAccessRequirement,
 } from '@sage-bionetworks/synapse-types'
@@ -77,7 +77,7 @@ export default function SelfSignAccessRequirementItem(
   })
 
   const onAcceptClicked = () => {
-    const accessApprovalRequest: AccessApproval = {
+    const accessApprovalRequest: CreateAccessApprovalRequest = {
       requirementId: accessRequirement?.id,
       submitterId: user?.ownerId!,
       accessorId: user?.ownerId!,

--- a/packages/synapse-react-client/src/components/AccessRequirementList/RequirementItem/UnmanagedACTAccessRequirementItem.stories.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/RequirementItem/UnmanagedACTAccessRequirementItem.stories.tsx
@@ -93,6 +93,12 @@ export const LegacyACTAccessRequirement: Story = {
               submitterId: MOCK_USER_ID.toString(),
               accessorId: MOCK_USER_ID.toString(),
               state: ApprovalState.APPROVED,
+              id: 123,
+              etag: 'etag',
+              createdOn: new Date().toISOString(),
+              modifiedOn: new Date().toISOString(),
+              createdBy: String(MOCK_USER_ID),
+              modifiedBy: String(MOCK_USER_ID),
             }
             return res(ctx.status(201), ctx.json(response))
           },
@@ -134,6 +140,12 @@ export const LegacyACTAccessRequirementWithWiki: Story = {
               submitterId: MOCK_USER_ID.toString(),
               accessorId: MOCK_USER_ID.toString(),
               state: ApprovalState.APPROVED,
+              id: 123,
+              etag: 'etag',
+              createdOn: new Date().toISOString(),
+              modifiedOn: new Date().toISOString(),
+              createdBy: String(MOCK_USER_ID),
+              modifiedBy: String(MOCK_USER_ID),
             }
             return res(ctx.status(201), ctx.json(response))
           },

--- a/packages/synapse-react-client/src/components/ChallengeRegisterButton/ChallengeRegisterButton.tsx
+++ b/packages/synapse-react-client/src/components/ChallengeRegisterButton/ChallengeRegisterButton.tsx
@@ -6,7 +6,7 @@ import { useSynapseContext } from '../../utils'
 import {
   useGetCurrentUserProfile,
   useGetEntityChallenge,
-  useGetUserSubmissionTeamsInfinite,
+  useGetUserSubmissionTeams,
 } from '../../synapse-queries'
 import { Challenge, PaginatedIds } from '@sage-bionetworks/synapse-types'
 import { useGetIsUserMemberOfTeam } from '../../synapse-queries/team/useTeamMembers'
@@ -77,7 +77,7 @@ const ChallengeRegisterButton = ({
     },
   )
 
-  useGetUserSubmissionTeamsInfinite(challenge?.id ?? '0', 20, {
+  useGetUserSubmissionTeams(challenge?.id ?? '0', 20, 0, {
     enabled: !!challenge && !!accessToken,
     onSettled: (data: PaginatedIds | undefined, error) => {
       if (data) {

--- a/packages/synapse-react-client/src/components/ChallengeSubmission/ChallengeSubmission.tsx
+++ b/packages/synapse-react-client/src/components/ChallengeSubmission/ChallengeSubmission.tsx
@@ -5,25 +5,25 @@ import {
   useGetEntityAlias,
   useGetEntityChallenge,
   useGetEntityPermissions,
-  useGetUserSubmissionTeamsInfinite,
+  useGetUserSubmissionTeams,
   useUpdateEntityACL,
 } from '../../synapse-queries'
 import { useSynapseContext } from '../../utils'
 import {
   ACCESS_TYPE,
   Challenge,
+  Entity,
+  EntityType,
   Project,
+  PROJECT_CONCRETE_TYPE_VALUE,
   ResourceAccess,
   Team,
 } from '@sage-bionetworks/synapse-types'
 import { ErrorBanner, SynapseErrorBoundary } from '../error/ErrorBanner'
 import { useGetTeam } from '../../synapse-queries/team/useTeam'
 import { createEntity } from '../../synapse-client'
-import { PROJECT_CONCRETE_TYPE_VALUE } from '@sage-bionetworks/synapse-types'
 import SubmissionDirectoryList from './SubmissionDirectoryList'
 import ChallengeSubmissionStepper from './ChallengeSubmissionStepper'
-import { EntityType } from '@sage-bionetworks/synapse-types'
-import { Entity } from '@sage-bionetworks/synapse-types'
 
 export type EntityItem = Entity & {
   repositoryName?: string
@@ -87,7 +87,7 @@ export function ChallengeSubmission({
   })
 
   // Determine whether or not the given user belongs to any submission teams
-  const { data: userSubmissionTeams } = useGetUserSubmissionTeamsInfinite(
+  const { data: userSubmissionTeams } = useGetUserSubmissionTeams(
     challenge?.id ?? EMPTY_ID,
     2,
   )

--- a/packages/synapse-react-client/src/components/ChallengeTeamWizard/ChallengeTeamWizard.test.tsx
+++ b/packages/synapse-react-client/src/components/ChallengeTeamWizard/ChallengeTeamWizard.test.tsx
@@ -16,7 +16,7 @@ import {
   mockChallengeTeamMembershipStatus,
   mockChallengeTeamResults,
   mockTeamList,
-} from '../../mocks/mockChallenge'
+} from '../../mocks/challenge/mockChallenge'
 import { mockUserProfileData } from '../../mocks/user/mock_user_profile'
 import { ChallengeTeamWizardProps } from './ChallengeTeamWizard'
 import userEvent from '@testing-library/user-event'

--- a/packages/synapse-react-client/src/components/ChallengeTeamWizard/ChallengeTeamWizard.tsx
+++ b/packages/synapse-react-client/src/components/ChallengeTeamWizard/ChallengeTeamWizard.tsx
@@ -21,7 +21,7 @@ import {
 import {
   useGetCurrentUserProfile,
   useGetEntityChallenge,
-  useGetUserSubmissionTeamsInfinite,
+  useGetUserSubmissionTeams,
 } from '../../synapse-queries'
 import { ANONYMOUS_PRINCIPAL_ID } from '../../utils/SynapseConstants'
 import { useGetMembershipStatus } from '../../synapse-queries/team/useTeamMembers'
@@ -165,7 +165,7 @@ const ChallengeTeamWizard: React.FunctionComponent<
 
   // Determine whether or not the given user belongs to any submission teams
   const { data: userSubmissionTeams, error: userSubmissionTeamError } =
-    useGetUserSubmissionTeamsInfinite(challenge?.id ?? EMPTY_ID, 1)
+    useGetUserSubmissionTeams(challenge?.id ?? EMPTY_ID, 1)
   useEffect(() => {
     if (userSubmissionTeams) {
       const isReg = userSubmissionTeams.results.length > 0

--- a/packages/synapse-react-client/src/components/GoogleMap/GoogleMap.integration.test.tsx
+++ b/packages/synapse-react-client/src/components/GoogleMap/GoogleMap.integration.test.tsx
@@ -7,18 +7,18 @@ import GoogleMap, { MapProps } from './GoogleMap'
 import { createWrapper } from '../../testutils/TestingLibraryUtils'
 import { rest, server } from '../../mocks/msw/server'
 import {
-  MOCK_TEAM_ID,
   MOCK_USER_ID,
   MOCK_USER_ID_2,
   MOCK_USER_NAME,
   MOCK_USER_NAME_2,
 } from '../../mocks/user/mock_user_profile'
 import {
-  LoadScript,
   GoogleMap as ReactGoogleMap,
-  Marker,
   InfoWindow,
+  LoadScript,
+  Marker,
 } from '@react-google-maps/api'
+import { MOCK_TEAM_ID } from '../../mocks/team/mockTeam'
 
 /** Mock the Google Maps library */
 jest.mock('@react-google-maps/api', () => ({

--- a/packages/synapse-react-client/src/mocks/challenge/mockChallenge.ts
+++ b/packages/synapse-react-client/src/mocks/challenge/mockChallenge.ts
@@ -1,17 +1,17 @@
 import {
   Challenge,
   ChallengeTeam,
+  ChallengeTeamPagedResults,
   ListWrapper,
-  PaginatedResults,
   Team,
   TeamMember,
   TeamMembershipStatus,
 } from '@sage-bionetworks/synapse-types'
-import { MOCK_USER_ID, mockUserGroupHeader } from './user/mock_user_profile'
+import { MOCK_USER_ID, mockUserGroupHeader } from '../user/mock_user_profile'
+import { MOCK_CHALLENGE_PARTICIPANT_TEAM_ID } from '../team/mockTeam'
 
 export const MOCK_CHALLENGE_ID = '1234'
 export const MOCK_CHALLENGE_PROJECT_ID = 'syn12345678'
-export const MOCK_PARTICIPANT_TEAM_ID = '123456'
 const etag = 'f1b29c62-e987-4e69-9cec-198bf017a586'
 
 const getRandomId = (len: number) => {
@@ -23,11 +23,11 @@ export const mockChallenge: Challenge = {
   id: MOCK_CHALLENGE_ID,
   etag,
   projectId: MOCK_CHALLENGE_PROJECT_ID,
-  participantTeamId: MOCK_PARTICIPANT_TEAM_ID,
+  participantTeamId: String(MOCK_CHALLENGE_PARTICIPANT_TEAM_ID),
 }
 
 export const mockChallengeTeamMember: TeamMember = {
-  teamId: MOCK_PARTICIPANT_TEAM_ID,
+  teamId: String(MOCK_CHALLENGE_PARTICIPANT_TEAM_ID),
   member: mockUserGroupHeader,
   isAdmin: false,
 }
@@ -37,7 +37,7 @@ export const mockChallengeTeamMembershipStatus = (
   canJoin: boolean = true,
 ): TeamMembershipStatus => {
   return {
-    teamId: MOCK_PARTICIPANT_TEAM_ID,
+    teamId: String(MOCK_CHALLENGE_PARTICIPANT_TEAM_ID),
     userId: MOCK_USER_ID.toString(),
     isMember,
     hasOpenInvitation: false,
@@ -49,7 +49,9 @@ export const mockChallengeTeamMembershipStatus = (
   }
 }
 
-export const mockChallengeTeam = (): ChallengeTeam => {
+export const mockChallengeTeam = (
+  override?: Partial<ChallengeTeam>,
+): ChallengeTeam => {
   const id: string = getRandomId(6).toString()
   const teamId: string = getRandomId(6).toString()
   return {
@@ -58,10 +60,11 @@ export const mockChallengeTeam = (): ChallengeTeam => {
     challengeId: MOCK_CHALLENGE_ID,
     teamId,
     message: `Message for team ${teamId}`,
+    ...override,
   }
 }
 
-export const mockChallengeTeamResults = (): PaginatedResults<ChallengeTeam> => {
+export const mockChallengeTeamResults = (): ChallengeTeamPagedResults => {
   const results: ChallengeTeam[] = []
   do {
     results.push(mockChallengeTeam())

--- a/packages/synapse-react-client/src/mocks/msw/handlers.ts
+++ b/packages/synapse-react-client/src/mocks/msw/handlers.ts
@@ -8,11 +8,7 @@ import {
   BackendDestinationEnum,
   getEndpoint,
 } from '../../utils/functions/getEndpoint'
-import {
-  getAccessRequirementEntityBindingHandlers,
-  getAccessRequirementHandlers,
-  getAccessRequirementStatusHandlers,
-} from './handlers/accessRequirementHandlers'
+import { getAllAccessRequirementHandlers } from './handlers/accessRequirementHandlers'
 import { getWikiHandlers } from './handlers/wikiHandlers'
 import { getDataAccessRequestHandlers } from './handlers/dataAccessRequestHandlers'
 import { getResearchProjectHandlers } from './handlers/researchProjectHandlers'
@@ -28,6 +24,8 @@ import {
 import { getEvaluationHandlers } from './handlers/evaluationHandlers'
 import { MOCK_ANNOTATION_COLUMNS } from '../mockAnnotationColumns'
 import { getPersonalAccessTokenHandlers } from './handlers/personalAccessTokenHandlers'
+import getAllChallengeHandlers from './handlers/challengeHandlers'
+import getAllTeamHandlers from './handlers/teamHandlers'
 
 // Simple utility type that just indicates that the response body could be an error like the Synapse backend may send.
 export type SynapseApiResponse<T> = T | SynapseError
@@ -49,9 +47,7 @@ const getHandlers = (backendOrigin: string) => [
   ...getUserProfileHandlers(backendOrigin),
   getCurrentUserCertifiedValidatedHandler(backendOrigin, true, true),
   ...getWikiHandlers(backendOrigin),
-  ...getAccessRequirementHandlers(backendOrigin),
-  ...getAccessRequirementEntityBindingHandlers(backendOrigin),
-  ...getAccessRequirementStatusHandlers(backendOrigin),
+  ...getAllAccessRequirementHandlers(backendOrigin),
   ...getDataAccessRequestHandlers(backendOrigin),
   ...getResearchProjectHandlers(backendOrigin),
   ...getFileHandlers(backendOrigin),
@@ -62,6 +58,8 @@ const getHandlers = (backendOrigin: string) => [
   ...getAnnotationColumnHandlers(MOCK_ANNOTATION_COLUMNS, backendOrigin),
   ...getDefaultColumnHandlers(backendOrigin),
   ...getPersonalAccessTokenHandlers(backendOrigin),
+  ...getAllTeamHandlers(backendOrigin),
+  ...getAllChallengeHandlers(backendOrigin),
 ]
 
 const handlers = getHandlers(getEndpoint(BackendDestinationEnum.REPO_ENDPOINT))

--- a/packages/synapse-react-client/src/mocks/msw/handlers/accessRequirementHandlers.ts
+++ b/packages/synapse-react-client/src/mocks/msw/handlers/accessRequirementHandlers.ts
@@ -5,10 +5,11 @@ import {
   ACCESS_REQUIREMENT_WIKI_PAGE_KEY,
   ENTITY_ACCESS_REQUIREMENTS,
 } from '../../../utils/APIConstants'
-import { MOCK_REPO_ORIGIN } from '../../../utils/functions/getEndpoint'
 import {
+  AccessApproval,
   AccessRequirement,
   AccessRequirementStatus,
+  CreateAccessApprovalRequest,
   MANAGED_ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
   ObjectType,
   PaginatedResults,
@@ -19,8 +20,13 @@ import { SynapseApiResponse } from '../handlers'
 import {
   mockAccessRequirements,
   mockAccessRequirementWikiPageKeys,
+  mockSelfSignAccessRequirement,
 } from '../../mockAccessRequirements'
 import { mockApprovedSubmission } from '../../dataaccess/MockSubmission'
+import { MOCK_USER_ID } from '../../user/mock_user_profile'
+
+const accessRequirementStatuses: Map<string, AccessRequirementStatus> =
+  new Map()
 
 export const getAccessRequirementHandlers = (backendOrigin: string) => [
   rest.get(
@@ -52,8 +58,8 @@ export const getAccessRequirementHandlers = (backendOrigin: string) => [
       }
       const wikiPageKey = mockAccessRequirementWikiPageKeys.find(
         wpk =>
-          (wpk.ownerObjectType === ObjectType.ACCESS_REQUIREMENT &&
-            wpk.ownerObjectId.toString()) === req.params.id,
+          wpk.ownerObjectType === ObjectType.ACCESS_REQUIREMENT &&
+          String(wpk.ownerObjectId) === req.params.id,
       )
 
       if (wikiPageKey) {
@@ -71,7 +77,7 @@ export const getAccessRequirementEntityBindingHandlers = (
   accessRequirements: AccessRequirement[] = mockAccessRequirements,
 ) => [
   rest.get(
-    `${MOCK_REPO_ORIGIN}${ENTITY_ACCESS_REQUIREMENTS(entityId)}`,
+    `${backendOrigin}${ENTITY_ACCESS_REQUIREMENTS(entityId)}`,
 
     async (req, res, ctx) => {
       const status = 200
@@ -84,43 +90,110 @@ export const getAccessRequirementEntityBindingHandlers = (
   ),
 ]
 
-export const getAccessRequirementStatusHandlers = (
+export const getAccessRequirementsBoundToTeamHandler = (
   backendOrigin: string,
-  arStatus: Record<string, AccessRequirementStatus> = {},
-) => [
+  accessRequirements: AccessRequirement[] = [mockSelfSignAccessRequirement],
+) =>
   rest.get(
-    `${backendOrigin}${ACCESS_REQUIREMENT_STATUS(':id')}`,
+    `${backendOrigin}/repo/v1/team/:teamId/accessRequirement`,
 
     async (req, res, ctx) => {
-      let response: AccessRequirementStatus | undefined
-      const accessRequirement = mockAccessRequirements.find(
-        accessRequirement => req.params.id === accessRequirement.id.toString(),
-      )
-      if (typeof req.params.id === 'string' && req.params.id in arStatus) {
-        response = arStatus[req.params.id]
+      const status = 200
+      const response: PaginatedResults<AccessRequirement> = {
+        results: accessRequirements,
+        totalNumberOfResults: accessRequirements.length,
       }
-      if (!response && accessRequirement) {
-        const isManagedACTAR =
-          accessRequirement.concreteType ===
-          MANAGED_ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE
-        response = {
-          accessRequirementId: req.params.id as string,
-          concreteType: isManagedACTAR
-            ? 'org.sagebionetworks.repo.model.dataaccess.ManagedACTAccessRequirementStatus'
-            : 'org.sagebionetworks.repo.model.dataaccess.BasicAccessRequirementStatus',
-          isApproved: true,
-          currentSubmissionStatus: isManagedACTAR
-            ? {
-                submissionId: mockApprovedSubmission.id,
-                submittedBy: mockApprovedSubmission.submittedBy,
-                modifiedOn: mockApprovedSubmission.modifiedOn,
-                state: SubmissionState.APPROVED,
-              }
-            : undefined,
-        }
-      }
-      const status = response ? 200 : 404
       return res(ctx.status(status), ctx.json(response))
     },
-  ),
-]
+  )
+
+export const getAccessRequirementStatusHandlers = (
+  backendOrigin: string,
+  arStatusOverrides?: AccessRequirementStatus[],
+) => {
+  if (arStatusOverrides) {
+    arStatusOverrides.forEach(override => {
+      accessRequirementStatuses.set(override.accessRequirementId, override)
+    })
+  }
+  return [
+    rest.get(
+      `${backendOrigin}${ACCESS_REQUIREMENT_STATUS(':id')}`,
+
+      async (req, res, ctx) => {
+        let response: AccessRequirementStatus | undefined
+        const accessRequirement = mockAccessRequirements.find(
+          accessRequirement =>
+            req.params.id === accessRequirement.id.toString(),
+        )
+        let override = accessRequirementStatuses.get(req.params.id as string)
+        if (override) {
+          response = override
+        }
+        if (!response && accessRequirement) {
+          const isManagedACTAR =
+            accessRequirement.concreteType ===
+            MANAGED_ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE
+          response = {
+            accessRequirementId: req.params.id as string,
+            concreteType: isManagedACTAR
+              ? 'org.sagebionetworks.repo.model.dataaccess.ManagedACTAccessRequirementStatus'
+              : 'org.sagebionetworks.repo.model.dataaccess.BasicAccessRequirementStatus',
+            isApproved: true,
+            currentSubmissionStatus: isManagedACTAR
+              ? {
+                  submissionId: mockApprovedSubmission.id,
+                  submittedBy: mockApprovedSubmission.submittedBy,
+                  modifiedOn: mockApprovedSubmission.modifiedOn,
+                  state: SubmissionState.APPROVED,
+                }
+              : undefined,
+          }
+        }
+        const status = response ? 200 : 404
+        return res(ctx.status(status), ctx.json(response))
+      },
+    ),
+  ]
+}
+
+export function getCreateAccessApprovalHandler(backendOrigin: string) {
+  return rest.post(
+    `${backendOrigin}/repo/v1/accessApproval`,
+
+    async (req, res, ctx) => {
+      const requestBody: CreateAccessApprovalRequest = await req.json()
+      const status = 200
+      const response: AccessApproval = {
+        ...requestBody,
+        id: 123,
+        etag: 'mock-etag',
+        createdOn: new Date().toISOString(),
+        modifiedOn: new Date().toISOString(),
+        createdBy: String(MOCK_USER_ID),
+        modifiedBy: String(MOCK_USER_ID),
+      }
+
+      // Update the corresponding status object
+      // TODO: Status should be inferred from the presence of an access approval, rather than the other way around
+      accessRequirementStatuses.set(String(requestBody.requirementId), {
+        accessRequirementId: String(requestBody.requirementId),
+        concreteType:
+          'org.sagebionetworks.repo.model.dataaccess.BasicAccessRequirementStatus',
+        isApproved: true,
+      })
+
+      return res(ctx.status(status), ctx.json(response))
+    },
+  )
+}
+
+export function getAllAccessRequirementHandlers(backendOrigin: string) {
+  return [
+    ...getAccessRequirementHandlers(backendOrigin),
+    ...getAccessRequirementEntityBindingHandlers(backendOrigin),
+    getAccessRequirementsBoundToTeamHandler(backendOrigin),
+    ...getAccessRequirementStatusHandlers(backendOrigin),
+    getCreateAccessApprovalHandler(backendOrigin),
+  ]
+}

--- a/packages/synapse-react-client/src/mocks/msw/handlers/challengeHandlers.ts
+++ b/packages/synapse-react-client/src/mocks/msw/handlers/challengeHandlers.ts
@@ -1,0 +1,101 @@
+import {
+  Challenge,
+  ChallengeTeam,
+  ChallengeTeamPagedResults,
+  CreateChallengeTeamRequest,
+  PaginatedIds,
+} from '@sage-bionetworks/synapse-types'
+import { SynapseApiResponse } from '../handlers'
+import { rest } from 'msw'
+import {
+  MOCK_CHALLENGE_ID,
+  mockChallengeTeam,
+} from '../../challenge/mockChallenge'
+import {
+  MOCK_CHALLENGE_PARTICIPANT_TEAM_ID,
+  MOCK_TEAM_ID_2,
+  MOCK_TEAM_ID_3,
+  MOCK_TEAM_ID_4,
+} from '../../team/mockTeam'
+import { uniqueId } from 'lodash-es'
+
+const registeredChallengeTeams = [
+  mockChallengeTeam({
+    teamId: String(MOCK_TEAM_ID_2),
+    challengeId: MOCK_CHALLENGE_ID,
+  }),
+  mockChallengeTeam({
+    teamId: String(MOCK_TEAM_ID_3),
+    challengeId: MOCK_CHALLENGE_ID,
+  }),
+  mockChallengeTeam({
+    teamId: String(MOCK_TEAM_ID_4),
+    challengeId: MOCK_CHALLENGE_ID,
+  }),
+]
+
+export function getChallengeHandler(backendOrigin: string) {
+  return rest.get(
+    `${backendOrigin}/repo/v1/entity/:id/challenge`,
+    async (req, res, ctx) => {
+      const response: SynapseApiResponse<Challenge> = {
+        id: MOCK_CHALLENGE_ID,
+        etag: 'f5e9df54-360b-4ede-9a17-f7f5680c8dd4',
+        projectId: req.params.id as string,
+        participantTeamId: String(MOCK_CHALLENGE_PARTICIPANT_TEAM_ID),
+      }
+      return res(ctx.status(200), ctx.json(response))
+    },
+  )
+}
+
+export function getRegisteredChallengeTeamsHandler(backendOrigin: string) {
+  return rest.get(
+    `${backendOrigin}/repo/v1/challenge/:challengeId/challengeTeam`,
+    async (req, res, ctx) => {
+      const response: SynapseApiResponse<ChallengeTeamPagedResults> = {
+        results: registeredChallengeTeams,
+        totalNumberOfResults: registeredChallengeTeams.length,
+      }
+      return res(ctx.status(200), ctx.json(response))
+    },
+  )
+}
+
+export function getRegisterTeamForChallengeHandler(backendOrigin: string) {
+  return rest.post(
+    `${backendOrigin}/repo/v1/challenge/:challengeId/challengeTeam`,
+    async (req, res, ctx) => {
+      const request: CreateChallengeTeamRequest = await req.json()
+      const response: SynapseApiResponse<ChallengeTeam> = {
+        ...request,
+        id: uniqueId(),
+        etag: 'abcdef0987654321',
+      }
+      registeredChallengeTeams.push(response)
+      return res(ctx.status(200), ctx.json(response))
+    },
+  )
+}
+
+export function getSubmissionTeamsHandler(backendOrigin: string) {
+  return rest.get(
+    `${backendOrigin}/repo/v1/challenge/:challengeId/submissionTeams`,
+    async (req, res, ctx) => {
+      const response: SynapseApiResponse<PaginatedIds> = {
+        results: [],
+        totalNumberOfResults: 0,
+      }
+      return res(ctx.status(200), ctx.json(response))
+    },
+  )
+}
+
+export default function getAllChallengeHandlers(backendOrigin: string) {
+  return [
+    getChallengeHandler(backendOrigin),
+    getSubmissionTeamsHandler(backendOrigin),
+    getRegisterTeamForChallengeHandler(backendOrigin),
+    getRegisteredChallengeTeamsHandler(backendOrigin),
+  ]
+}

--- a/packages/synapse-react-client/src/mocks/msw/handlers/teamHandlers.ts
+++ b/packages/synapse-react-client/src/mocks/msw/handlers/teamHandlers.ts
@@ -1,0 +1,105 @@
+import { Team, TeamMembershipStatus } from '@sage-bionetworks/synapse-types'
+import { SynapseApiResponse } from '../handlers'
+import { rest } from 'msw'
+import { mockTeamMembershipStatuses, mockTeams } from '../../team/mockTeam'
+
+const teams: Team[] = [...mockTeams]
+
+function getMockTeamById(id: string): Team | undefined {
+  return teams.find(team => team.id === id)
+}
+
+const teamMemberships: TeamMembershipStatus[] = [...mockTeamMembershipStatuses]
+function getTeamMembershipStatusByTeamIdMemberId(
+  teamId: string,
+  memberId: string,
+): TeamMembershipStatus | undefined {
+  return teamMemberships.find(
+    membership =>
+      membership.teamId === teamId && membership.userId === memberId,
+  )
+}
+
+function addTeamMembershipStatus(teamMembershipStatus: TeamMembershipStatus) {
+  teamMemberships.push(teamMembershipStatus)
+}
+
+export function getTeamMembershipStatusHandler(backendOrigin: string) {
+  return rest.get(
+    `${backendOrigin}/repo/v1/team/:teamId/member/:memberId/membershipStatus`,
+    async (req, res, ctx) => {
+      const teamId = req.params.teamId as string
+      const memberId = req.params.memberId as string
+      let response: SynapseApiResponse<TeamMembershipStatus>
+      let status: number
+
+      const team = getMockTeamById(teamId)
+      if (!team) {
+        response = {
+          reason: `getTeamMembershipStatusHandler could not locate a team with ID ${teamId}`,
+        }
+        status = 404
+      } else {
+        const membershipStatus: TeamMembershipStatus =
+          getTeamMembershipStatusByTeamIdMemberId(teamId, memberId) ?? {
+            teamId: teamId,
+            userId: memberId,
+            isMember: false,
+            hasOpenInvitation: false, // TODO
+            hasOpenRequest: false, // TODO
+            canJoin: true, // TODO
+            membershipApprovalRequired: false, // TODO
+            hasUnmetAccessRequirement: false, // TODO
+            canSendEmail: false, // TODO
+          }
+
+        response = membershipStatus
+        status = 200
+      }
+      return res(ctx.status(status), ctx.json(response))
+    },
+  )
+}
+
+export function getUpdateTeamMembershipStatusHandler(backendOrigin: string) {
+  return rest.put(
+    `${backendOrigin}/repo/v1/team/:teamId/member/:memberId`,
+    async (req, res, ctx) => {
+      const teamId = req.params.teamId as string
+      const memberId = req.params.memberId as string
+      let response: SynapseApiResponse<void> | ''
+      let status: number
+
+      const team = getMockTeamById(teamId)
+      if (!team) {
+        response = {
+          reason: `getTeamMembershipStatusHandler could not locate a team with ID ${teamId}`,
+        }
+        status = 404
+      } else {
+        const membershipStatus: TeamMembershipStatus = {
+          teamId: teamId,
+          userId: memberId,
+          isMember: true,
+          hasOpenInvitation: false, // TODO
+          hasOpenRequest: false, // TODO
+          canJoin: true, // TODO
+          membershipApprovalRequired: false, // TODO
+          hasUnmetAccessRequirement: false, // TODO
+          canSendEmail: false, // TODO
+        }
+        addTeamMembershipStatus(membershipStatus)
+        response = ''
+        status = 201
+      }
+      return res(ctx.status(status), ctx.json(response))
+    },
+  )
+}
+
+export default function getAllTeamHandlers(backendOrigin: string) {
+  return [
+    getTeamMembershipStatusHandler(backendOrigin),
+    getUpdateTeamMembershipStatusHandler(backendOrigin),
+  ]
+}

--- a/packages/synapse-react-client/src/mocks/msw/handlers/userProfileHandlers.ts
+++ b/packages/synapse-react-client/src/mocks/msw/handlers/userProfileHandlers.ts
@@ -29,6 +29,7 @@ import {
 } from '../../user/mock_user_profile'
 import { SynapseApiResponse } from '../handlers'
 import { UserProfileList } from '../../../synapse-client/SynapseClient'
+import { mockUserGroupData } from '../../usergroup/mockUserGroup'
 
 export const getUserProfileHandlers = (backendOrigin: string) => [
   /**
@@ -109,7 +110,7 @@ export const getUserProfileHandlers = (backendOrigin: string) => [
     async (req, res, ctx) => {
       const ids = req.url.searchParams.get('ids')!.split(',')
       const responsePage: UserGroupHeaderResponsePage = {
-        children: mockUserData
+        children: mockUserGroupData
           .filter(userData => ids.includes(userData.id.toString()))
           .map(userData => userData.userGroupHeader),
       }
@@ -140,7 +141,7 @@ export const getUserProfileHandlers = (backendOrigin: string) => [
     const prefix = (req.url.searchParams.get('prefix') ?? '').toLowerCase()
     const typeFilter = req.url.searchParams.get('typeFilter') as TYPE_FILTER
     const responsePage: UserGroupHeaderResponsePage = {
-      children: mockUserData
+      children: mockUserGroupData
         .filter(userData => {
           if (!typeFilter || typeFilter === TYPE_FILTER.ALL) {
             return true

--- a/packages/synapse-react-client/src/mocks/msw/handlers/wikiHandlers.ts
+++ b/packages/synapse-react-client/src/mocks/msw/handlers/wikiHandlers.ts
@@ -1,6 +1,6 @@
 import { rest } from 'msw'
 import { ACCESS_REQUIREMENT_WIKI_PAGE } from '../../../utils/APIConstants'
-import { WikiPage } from '@sage-bionetworks/synapse-types'
+import { FileHandleResults, WikiPage } from '@sage-bionetworks/synapse-types'
 import { SynapseApiResponse } from '../handlers'
 import { mockWikiPages } from '../../mockWiki'
 
@@ -17,6 +17,16 @@ export const getWikiHandlers = (backendOrigin: string) => [
       if (wikiPage) {
         response = wikiPage
         status = 200
+      }
+      return res(ctx.status(status), ctx.json(response))
+    },
+  ),
+  rest.get(
+    `${backendOrigin}/repo/v1/:objectType/:objectId/wiki2/:wikiId/attachmenthandles`,
+    async (req, res, ctx) => {
+      let status = 200
+      let response: SynapseApiResponse<FileHandleResults> = {
+        list: [],
       }
       return res(ctx.status(status), ctx.json(response))
     },

--- a/packages/synapse-react-client/src/mocks/team/mockTeam.ts
+++ b/packages/synapse-react-client/src/mocks/team/mockTeam.ts
@@ -1,0 +1,160 @@
+import { Team, TeamMembershipStatus } from '@sage-bionetworks/synapse-types'
+import {
+  MOCK_USER_ID,
+  MOCK_USER_ID_2,
+  MockUserOrTeamData,
+} from '../user/mock_user_profile'
+import { ACT_TEAM_ID } from '../../utils/SynapseConstants'
+
+export const MOCK_TEAM_ID = 987654
+export const MOCK_TEAM_ID_2 = 987655
+export const MOCK_TEAM_ID_3 = 987656
+export const MOCK_TEAM_ID_4 = 987657
+export const MOCK_CHALLENGE_PARTICIPANT_TEAM_ID = 987658
+
+export const mockTeamData: Readonly<Team> = {
+  id: String(MOCK_TEAM_ID),
+  name: 'Mock Team',
+  description: 'A team that already has super cool fake users',
+  icon: '',
+  canPublicJoin: true,
+  canRequestMembership: true,
+  etag: 'f29b79d6-5b63-4641-93c7-30d954b4328c',
+  createdOn: '2013-11-02T01:01:18.373Z',
+  modifiedOn: '2019-01-31T20:34:40.057Z',
+  createdBy: String(MOCK_USER_ID),
+  modifiedBy: String(MOCK_USER_ID_2),
+}
+
+export const mockTeamData2: Readonly<Team> = {
+  id: String(MOCK_TEAM_ID_2),
+  name: 'Mock team public can join',
+  description: 'A team for fake users to join',
+  icon: '',
+  canPublicJoin: true,
+  canRequestMembership: false,
+  etag: 'f29b79d6-5b63-4641-93c7-30d954b4328c',
+  createdOn: '2013-11-02T01:01:18.373Z',
+  modifiedOn: '2019-01-31T20:34:40.057Z',
+  createdBy: String(MOCK_USER_ID),
+  modifiedBy: String(MOCK_USER_ID_2),
+}
+
+export const mockTeamData3: Readonly<Team> = {
+  id: String(MOCK_TEAM_ID_3),
+  name: 'Mock team public can request to join',
+  description: 'A team for fake users to request to join',
+  icon: '',
+  canPublicJoin: false,
+  canRequestMembership: true,
+  etag: 'f29b79d6-5b63-4641-93c7-30d954b4328c',
+  createdOn: '2013-11-02T01:01:18.373Z',
+  modifiedOn: '2019-01-31T20:34:40.057Z',
+  createdBy: String(MOCK_USER_ID),
+  modifiedBy: String(MOCK_USER_ID_2),
+}
+
+export const mockTeamData4: Readonly<Team> = {
+  id: String(MOCK_TEAM_ID_4),
+  name: 'Mock team with open invitation',
+  description: 'A team that fake users have been invited to join',
+  icon: '',
+  canPublicJoin: false,
+  canRequestMembership: false,
+  etag: 'f29b79d6-5b63-4641-93c7-30d954b4328c',
+  createdOn: '2013-11-02T01:01:18.373Z',
+  modifiedOn: '2019-01-31T20:34:40.057Z',
+  createdBy: String(MOCK_USER_ID),
+  modifiedBy: String(MOCK_USER_ID_2),
+}
+
+export const mockChallengeParticipantTeamData: Readonly<Team> = {
+  id: String(MOCK_CHALLENGE_PARTICIPANT_TEAM_ID),
+  name: 'Mock team with open invitation',
+  description: 'A team that users must join to participate in the challenge',
+  icon: '',
+  canPublicJoin: true,
+  etag: 'f29b79d6-5b63-4641-93c7-30d954b4328c',
+  createdOn: '2013-11-02T01:01:18.373Z',
+  modifiedOn: '2019-01-31T20:34:40.057Z',
+  createdBy: String(MOCK_USER_ID),
+  modifiedBy: String(MOCK_USER_ID_2),
+}
+
+export const mockTeamUserGroup: MockUserOrTeamData = {
+  id: MOCK_TEAM_ID,
+  userProfile: null,
+  userBundle: null,
+  userGroupHeader: {
+    ownerId: MOCK_TEAM_ID.toString(),
+    userName: mockTeamData.name,
+    isIndividual: false,
+  },
+}
+
+export const mockActData: MockUserOrTeamData = {
+  id: ACT_TEAM_ID,
+  userProfile: null,
+  userBundle: null,
+  userGroupHeader: {
+    ownerId: ACT_TEAM_ID.toString(),
+    userName: 'Synapse Access and Compliance Team',
+    isIndividual: false,
+  },
+}
+
+export const mockTeams: readonly Readonly<Team>[] = [
+  mockTeamData,
+  mockTeamData2,
+  mockTeamData3,
+  mockTeamData4,
+  mockChallengeParticipantTeamData,
+]
+
+export const mockTeamMembershipStatuses: readonly Readonly<TeamMembershipStatus>[] =
+  [
+    {
+      teamId: mockTeamData.id,
+      userId: String(MOCK_USER_ID),
+      isMember: true,
+      hasOpenInvitation: false,
+      hasOpenRequest: false,
+      canJoin: true,
+      membershipApprovalRequired: true,
+      hasUnmetAccessRequirement: false,
+      canSendEmail: true,
+    },
+    {
+      teamId: mockTeamData2.id,
+      userId: String(MOCK_USER_ID),
+      isMember: false,
+      hasOpenInvitation: false,
+      hasOpenRequest: false,
+      canJoin: true,
+      membershipApprovalRequired: false,
+      hasUnmetAccessRequirement: false,
+      canSendEmail: false,
+    },
+    {
+      teamId: mockTeamData3.id,
+      userId: String(MOCK_USER_ID),
+      isMember: false,
+      hasOpenInvitation: false,
+      hasOpenRequest: false,
+      canJoin: false,
+      membershipApprovalRequired: true,
+      hasUnmetAccessRequirement: false,
+      canSendEmail: false,
+    },
+    {
+      teamId: mockTeamData4.id,
+      userId: String(MOCK_USER_ID),
+      isMember: false,
+      hasOpenInvitation: true,
+      hasOpenRequest: false,
+      canJoin: false,
+      membershipApprovalRequired: true,
+      hasUnmetAccessRequirement: false,
+      canSendEmail: false,
+    },
+  ]

--- a/packages/synapse-react-client/src/mocks/user/mock_user_profile.ts
+++ b/packages/synapse-react-client/src/mocks/user/mock_user_profile.ts
@@ -114,7 +114,7 @@ export const mockUserGroupHeader3: UserGroupHeader = {
   isIndividual: true,
 }
 
-type MockUserOrTeamData = {
+export type MockUserOrTeamData = {
   id: number
   userProfile: UserProfile | null
   userBundle: UserBundle | null

--- a/packages/synapse-react-client/src/mocks/user/mock_user_profile.ts
+++ b/packages/synapse-react-client/src/mocks/user/mock_user_profile.ts
@@ -1,9 +1,4 @@
 import {
-  ACT_TEAM_ID,
-  AUTHENTICATED_PRINCIPAL_ID,
-  PUBLIC_PRINCIPAL_ID,
-} from '../../utils/SynapseConstants'
-import {
   UserBundle,
   UserGroupHeader,
   UserProfile,
@@ -126,79 +121,29 @@ type MockUserOrTeamData = {
   userGroupHeader: UserGroupHeader
 }
 
-const mockUserData1: MockUserOrTeamData = {
+export const mockUserData1: MockUserOrTeamData = {
   id: MOCK_USER_ID,
   userProfile: mockUserProfileData,
   userBundle: mockUserBundle,
   userGroupHeader: mockUserGroupHeader,
 }
 
-const mockUserData2: MockUserOrTeamData = {
+export const mockUserData2: MockUserOrTeamData = {
   id: MOCK_USER_ID_2,
   userProfile: mockUserProfileData2,
   userBundle: mockUserBundle2,
   userGroupHeader: mockUserGroupHeader2,
 }
 
-const mockUserData3: MockUserOrTeamData = {
+export const mockUserData3: MockUserOrTeamData = {
   id: MOCK_USER_ID_3,
   userProfile: mockUserProfileData3,
   userBundle: mockUserBundle3,
   userGroupHeader: mockUserGroupHeader3,
 }
 
-export const MOCK_TEAM_ID = 987654
-
-export const mockTeamData: MockUserOrTeamData = {
-  id: MOCK_TEAM_ID,
-  userProfile: null,
-  userBundle: null,
-  userGroupHeader: {
-    ownerId: MOCK_TEAM_ID.toString(),
-    userName: 'Mock Team',
-    isIndividual: false,
-  },
-}
-
-const mockActData: MockUserOrTeamData = {
-  id: ACT_TEAM_ID,
-  userProfile: null,
-  userBundle: null,
-  userGroupHeader: {
-    ownerId: ACT_TEAM_ID.toString(),
-    userName: 'Synapse Access and Compliance Team',
-    isIndividual: false,
-  },
-}
-
-const mockPublicGroupData: MockUserOrTeamData = {
-  id: PUBLIC_PRINCIPAL_ID,
-  userProfile: null,
-  userBundle: null,
-  userGroupHeader: {
-    ownerId: PUBLIC_PRINCIPAL_ID.toString(),
-    userName: 'PUBLIC',
-    isIndividual: false,
-  },
-}
-
-const mockAuthenticatedGroupData: MockUserOrTeamData = {
-  id: AUTHENTICATED_PRINCIPAL_ID,
-  userProfile: null,
-  userBundle: null,
-  userGroupHeader: {
-    ownerId: AUTHENTICATED_PRINCIPAL_ID.toString(),
-    userName: 'AUTHENTICATED_USERS',
-    isIndividual: false,
-  },
-}
-
 export const mockUserData: MockUserOrTeamData[] = [
   mockUserData1,
   mockUserData2,
   mockUserData3,
-  mockTeamData,
-  mockActData,
-  mockAuthenticatedGroupData,
-  mockPublicGroupData,
 ]

--- a/packages/synapse-react-client/src/mocks/usergroup/mockUserGroup.ts
+++ b/packages/synapse-react-client/src/mocks/usergroup/mockUserGroup.ts
@@ -1,0 +1,41 @@
+import {
+  mockUserData1,
+  mockUserData2,
+  mockUserData3,
+  MockUserOrTeamData,
+} from '../user/mock_user_profile'
+import { mockActData, mockTeamUserGroup } from '../team/mockTeam'
+import {
+  AUTHENTICATED_PRINCIPAL_ID,
+  PUBLIC_PRINCIPAL_ID,
+} from '../../utils/SynapseConstants'
+
+export const mockPublicGroupData: MockUserOrTeamData = {
+  id: PUBLIC_PRINCIPAL_ID,
+  userProfile: null,
+  userBundle: null,
+  userGroupHeader: {
+    ownerId: PUBLIC_PRINCIPAL_ID.toString(),
+    userName: 'PUBLIC',
+    isIndividual: false,
+  },
+}
+export const mockAuthenticatedGroupData: MockUserOrTeamData = {
+  id: AUTHENTICATED_PRINCIPAL_ID,
+  userProfile: null,
+  userBundle: null,
+  userGroupHeader: {
+    ownerId: AUTHENTICATED_PRINCIPAL_ID.toString(),
+    userName: 'AUTHENTICATED_USERS',
+    isIndividual: false,
+  },
+}
+export const mockUserGroupData: MockUserOrTeamData[] = [
+  mockUserData1,
+  mockUserData2,
+  mockUserData3,
+  mockTeamUserGroup,
+  mockActData,
+  mockAuthenticatedGroupData,
+  mockPublicGroupData,
+]

--- a/packages/synapse-react-client/src/synapse-client/SynapseClient.ts
+++ b/packages/synapse-react-client/src/synapse-client/SynapseClient.ts
@@ -128,6 +128,7 @@ import {
   ChangePasswordWithCurrentPassword,
   ChangePasswordWithToken,
   ColumnModel,
+  CreateAccessApprovalRequest,
   CreateChallengeTeamRequest,
   CreateDiscussionReply,
   CreateDiscussionThread,
@@ -1444,7 +1445,7 @@ export const addTeamMemberAsAuthenticatedUserOrAdmin = (
   memberId: string,
   accessToken: string,
 ) => {
-  return doPut(
+  return doPut<void>(
     TEAM_ID_MEMBER_ID_WITH_NOTIFICATION(teamId, memberId),
     undefined,
     accessToken,
@@ -3018,7 +3019,7 @@ export const getAccessApproval = async (
  */
 export const createAccessApproval = async (
   accessToken: string | undefined,
-  accessApproval: AccessApproval,
+  accessApproval: CreateAccessApprovalRequest,
 ): Promise<AccessApproval> => {
   return doPost<AccessApproval>(
     ACCESS_APPROVAL,

--- a/packages/synapse-react-client/src/synapse-queries/KeyFactory.ts
+++ b/packages/synapse-react-client/src/synapse-queries/KeyFactory.ts
@@ -648,8 +648,12 @@ export class KeyFactory {
     return this.getKey('passingRecord', userId)
   }
 
-  public getSubmissionTeamsQueryKey(challengeId: string) {
-    return this.getKey('submissionTeams', challengeId)
+  public getSubmissionTeamsQueryKey(
+    challengeId: string,
+    limit?: number,
+    offset?: number,
+  ) {
+    return this.getKey('submissionTeams', challengeId, { limit, offset })
   }
 
   public getUserProjectsQueryKey(

--- a/packages/synapse-react-client/src/synapse-queries/user/useGetUserTeams.ts
+++ b/packages/synapse-react-client/src/synapse-queries/user/useGetUserTeams.ts
@@ -16,8 +16,8 @@ import { getNextPageParamForPaginatedResults } from '../InfiniteQueryUtils'
 
 export function useGetUserSubmissionTeams(
   challengeId: string,
-  limit?: number,
-  offset: number = 10,
+  limit: number = 10,
+  offset?: number,
   options?: UseQueryOptions<PaginatedIds, SynapseClientError>,
 ) {
   const { accessToken, keyFactory } = useSynapseContext()
@@ -29,13 +29,13 @@ export function useGetUserSubmissionTeams(
         accessToken,
         challengeId,
         offset,
-        limit ?? 10,
+        limit,
       )
     },
     {
       ...options,
       getNextPageParam: (lastPage, pages) => {
-        if (lastPage.results.length > 0) return pages.length * (limit ?? 10)
+        if (lastPage.results.length > 0) return pages.length * limit
         //set the new offset to (page * limit)
         else return undefined
       },

--- a/packages/synapse-react-client/src/synapse-queries/user/useGetUserTeams.ts
+++ b/packages/synapse-react-client/src/synapse-queries/user/useGetUserTeams.ts
@@ -7,24 +7,28 @@ import {
 import SynapseClient from '../../synapse-client'
 import { SynapseClientError } from '../../utils/SynapseClientError'
 import { useSynapseContext } from '../../utils/context/SynapseContext'
-import { PaginatedIds, PaginatedResults } from '@sage-bionetworks/synapse-types'
-import { Team } from '@sage-bionetworks/synapse-types'
+import {
+  PaginatedIds,
+  PaginatedResults,
+  Team,
+} from '@sage-bionetworks/synapse-types'
 import { getNextPageParamForPaginatedResults } from '../InfiniteQueryUtils'
 
-export function useGetUserSubmissionTeamsInfinite(
+export function useGetUserSubmissionTeams(
   challengeId: string,
   limit?: number,
+  offset: number = 10,
   options?: UseQueryOptions<PaginatedIds, SynapseClientError>,
 ) {
   const { accessToken, keyFactory } = useSynapseContext()
 
   return useQuery<PaginatedIds, SynapseClientError>(
-    keyFactory.getSubmissionTeamsQueryKey(challengeId),
-    async context => {
+    keyFactory.getSubmissionTeamsQueryKey(challengeId, limit, offset),
+    async () => {
       return SynapseClient.getSubmissionTeams(
         accessToken,
         challengeId,
-        context.pageParam, // pass the context.pageParam for the new offset,
+        offset,
         limit ?? 10,
       )
     },

--- a/packages/synapse-types/src/AccessApproval.ts
+++ b/packages/synapse-types/src/AccessApproval.ts
@@ -28,12 +28,12 @@ export interface AccessApprovalSearchResult {
 }
 
 export interface AccessApproval {
-  id?: number //	The unique immutable ID
-  etag?: string //	Synapse employs an Optimistic Concurrency Control (OCC) scheme to handle concurrent updates. Since the E-Tag changes every time an entity is updated it is used to detect when a client's current representation of an object is out-of-date.
-  createdOn?: string //	The date this object was created.
-  modifiedOn?: string //	The date this object was last modified.
-  createdBy?: string //	The user that created this object.
-  modifiedBy?: string //	The user that last modified this object.
+  id: number //	The unique immutable ID
+  etag: string //	Synapse employs an Optimistic Concurrency Control (OCC) scheme to handle concurrent updates. Since the E-Tag changes every time an entity is updated it is used to detect when a client's current representation of an object is out-of-date.
+  createdOn: string //	The date this object was created.
+  modifiedOn: string //	The date this object was last modified.
+  createdBy: string //	The user that created this object.
+  modifiedBy: string //	The user that last modified this object.
   requirementId: number //	The ID of the Access Requirement that this object approves.
   requirementVersion?: number //	The version of the Access Requirement that this object approves.
   submitterId: string //	The user who performed the necessary action(s) to gain this approval.
@@ -41,6 +41,15 @@ export interface AccessApproval {
   expiredOn?: string //	The date this object will be expired.
   state: ApprovalState //	JSON enum for the state of AccessApproval
 }
+
+export type CreateAccessApprovalRequest = Pick<
+  AccessApproval,
+  | 'requirementId'
+  | 'requirementVersion'
+  | 'submitterId'
+  | 'accessorId'
+  | 'state'
+>
 
 export interface AccessApprovalSearchRequest {
   accessorId: string // 	Filter by the id of the principal that is an accessor in the approval. Note that the submitter is always part of the accessors. This field is required.


### PR DESCRIPTION
PORTALS-2936 - Update types, mocks, handlers

- Add `CreateAccessApprovalRequest` type, update `AccessApproval` properties to be required if they are always returned by the result object. Update types and objects to fix compile errors
- Rename `useGetUserSubmissionTeamsInfinite` to `useGetUserSubmissionTeams` -- it did not use `useInfiniteQuery`
- Add `useAddMemberToTeam` mutation
- Update cache invalidation for `useDeleteTeamMembership` to include membership status query
- Add useGetAccessRequirementStatuses for querying the current user's status across an array of ARs
- Move team, usergroup mocks to different files
- Add handlers for teams, challenges, access requirements

PORTALS-2936 - Add missing export